### PR TITLE
Fix include guard.

### DIFF
--- a/src/ExtensionChecker.h
+++ b/src/ExtensionChecker.h
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *****************************************************************************/
 
-#ifndef EXTENSION_CHECKER_H
+#ifndef EXTENSION_CHECKER_H_
 #define EXTENSION_CHECKER_H_
 
 bool isExtensionSupported( const char *extension );


### PR DESCRIPTION
    ../../src/ExtensionChecker.h:22:9: warning: 'EXTENSION_CHECKER_H' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
    #ifndef EXTENSION_CHECKER_H
            ^~~~~~~~~~~~~~~~~~~