### PR TITLE
Fixed crash in StringFunctions::trim()

### DIFF
--- a/src/config/StringFunctions.cpp
+++ b/src/config/StringFunctions.cpp
@@ -98,6 +98,12 @@ void trim(string& str, bool left, bool right, const string delims)
 //-----------------------------------------------------------------------------
 char* trim(char* str, bool left, bool right)
 {
+    // Empty string check
+    if (*str == '\0')
+    {
+        return str;
+    }
+
     //Trim from the left
     if(left)
     {


### PR DESCRIPTION
Fixed a crash in StringFunctions::trim(char*, bool, bool) caused by attempting to remove whitespace from an empty string.  Added a check for an empty string at the beginning of the function.