### PR TITLE
Set viewport when initializing window

### DIFF
--- a/src/OpenGLManager.cpp
+++ b/src/OpenGLManager.cpp
@@ -58,6 +58,7 @@ bool OpenGLManager::initialize(bool fullscreen, int width, int height, int bitDe
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
+    this->setViewport(0, 0, width, height);
 
     //Set render states
     setCullMode(false, true);


### PR DESCRIPTION
Set the viewport when initializing the window.  This is significant when using non-native resolutions in fullscreen, as not setting the viewport results is graphical glitches.