### PR TITLE
CI/CD: Fixes Ubuntu i386 builds, among other changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,11 +45,7 @@ jobs:
           if [[ ${{ matrix.bits }} -eq 32 ]]; then sudo dpkg --add-architecture i386; fi
           sudo apt-get update
           sudo apt-get -y install libgl1-mesa-dev
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then
-            sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386 libgl1-mesa-glx:i386
-            cd /usr/lib/i386-linux-gnu
-            if ! [[ -f libGL.so ]]; then sudo ln -s -T libGL.so.1.7.0 libGL.so; fi
-          fi
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386 libatomic1:i386 libgcc-s1:i386 libstdc++6:i386 libgl1-mesa-dev:i386; fi
           sudo ldconfig
       - name: Build and related stuff, backup binaries
         run: |
@@ -190,9 +186,11 @@ jobs:
             tigerdeep -lz ${BIN} >> ../${BIN:0:27}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:27}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:27}.sha512.txt
+            b2sum ${BIN} >> ../${BIN:0:27}.blake2.txt
           done
           mv ../*.tiger.txt .
           mv ../*.sha*.txt .
+          mv ../*.blake2.txt .
           echo ""
           echo "TIGER:"
           cat *.tiger.txt
@@ -202,6 +200,9 @@ jobs:
           echo ""
           echo "SHA512:"
           cat *.sha512.txt
+          echo ""
+          echo "BLAKE2:"
+          cat *.blake2.txt
           echo ""
           git tag -f nightly-build
           git push -f origin nightly-build


### PR DESCRIPTION
> This scheduled workflow is disabled because there hasn't been activity in this repository for at least 60 days. Enable this workflow to resume scheduled runs.

This is disabling all GitHub Actions, not just scheduled workflows... to re-enable: Actions > Arachnoid